### PR TITLE
README.md: Force --strict-channel-priority on xtensor install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Run test upload CLI client:
 
 Install the test package with conda:
 ```
-mamba install -c http://localhost:8000/static/channels/channel0 -c conda-forge xtensor
+mamba install --strict-channel-priority -c http://localhost:8000/static/channels/channel0 -c conda-forge xtensor
 ```
 
 Output:


### PR DESCRIPTION
Without having previously set `config --set channel_priority strict` the install for xtensor will resolve to the `conda-forge` package due to the higher version number `xtensor-0.21.5`