### PR TITLE
Redirect to the root after auth/logout

### DIFF
--- a/quetz/auth_github.py
+++ b/quetz/auth_github.py
@@ -59,7 +59,7 @@ async def authorize(request: Request):
 
     request.session['token'] = json.dumps(token)
 
-    resp = RedirectResponse('/static/index.html')
+    resp = RedirectResponse('/')
 
     return resp
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -108,7 +108,7 @@ def logout(session):
 @app.route('/auth/logout')
 async def route_logout(request):
     logout(request.session)
-    return RedirectResponse('/static/index.html')
+    return RedirectResponse('/')
 
 
 @api_router.get('/dummylogin/{username}', tags=['dev'])
@@ -122,7 +122,7 @@ def dummy_login(
     session['user_id'] = str(uuid.UUID(bytes=user.id))
 
     session['identity_provider'] = 'dummy'
-    return RedirectResponse('/static/index.html')
+    return RedirectResponse('/')
 
 
 @api_router.get('/me', response_model=rest_models.Profile, tags=['users'])


### PR DESCRIPTION
Allow the web application to serve either the new frontend if available
or the static index.html.