### PR TITLE
quetz_client/meta.yaml: Ensure compatibility for conda-build 3+

### DIFF
--- a/quetz_client/meta.yaml
+++ b/quetz_client/meta.yaml
@@ -10,17 +10,17 @@ source:
 
 build:
   noarch: python
-  skip: true  # [win and py27]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-  build:
-    - python
+  host:
+    - python >=3.6
+    - pip
     - setuptools
 
   run:
-    - python
+    - python >=3.6
     - requests >=2,<3
     - conda-verify >=3,<4
     - conda-build >=3,<4


### PR DESCRIPTION
Host depending on python doesn't ensure pip is available, for
example if 'add_pip_as_python_dependency' is disabled in conda
config. Update to 'host' instead of 'build' as targeting
conda-build 3, pre-process selectors for noarch packages should
also not be used.

conda-smithy explicitly sets this to false by default in it's conda-forge feedstock package builds, see
https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/master/recipe/run_conda_forge_build_setup_linux#L7 

See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#architecture-independent-packages for the `Warning` about pre-process selectors on noarch