### PR TITLE
Quetz cli

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 graft quetz/basic_frontend
+include quetz/config.toml

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pip install -e quetz
 Use the CLI to create a `Quetz` instance:
 
 ```
-quetz run test_quetz --create-conf --test --reload
+quetz run test_quetz --create-conf --dev --reload
 ```
 
 Links:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ mamba create -n quetz -c conda-forge 'python>=3.7' fastapi authlib httpx=0.12.0 
 python-multipart uvicorn zstandard conda-build appdirs toml quetz-client
 
 conda activate quetz
+pip install typer
 ```
 
 Get `Quetz` sources:
@@ -47,7 +48,7 @@ git clone https://github.com/TheSnakePit/quetz.git quetz
 Install `Quetz` in editable mode:
 
 ```
-pip install -no-deps -e ./quetz 
+pip install --no-deps -e ./quetz 
 ```
 
 Use the CLI to create a `Quetz` instance:

--- a/README.md
+++ b/README.md
@@ -37,28 +37,23 @@ python-multipart uvicorn zstandard conda-build appdirs toml quetz-client
 conda activate quetz
 ```
 
-Initialize environment variables:
+Get `Quetz` sources:
 
 ```
-source ./set_env_dev.sh
+mkdir quetz
+git clone https://github.com/TheSnakePit/quetz.git quetz
 ```
 
-Initialize test database:
+Install `Quetz` in editable mode:
 
 ```
-python init_db.py
+pip install -no-deps -e ./quetz 
 ```
 
-Create a directory to store channels
+Use the CLI to create a `Quetz` instance:
 
 ```
-mkdir channels
-```
-
-Run the fastapi server:
-
-```
-uvicorn quetz.main:app --reload
+python quetz/quetz/cli.py run test_quetz --create-conf --test --reload
 ```
 
 Links:

--- a/README.md
+++ b/README.md
@@ -45,16 +45,18 @@ mkdir quetz
 git clone https://github.com/TheSnakePit/quetz.git quetz
 ```
 
-Install `Quetz` in editable mode:
+Install `Quetz`:
+
+> Use the editable mode `-e` if you are developer and want to take advantage of the `reload` option of `Quetz`
 
 ```
-pip install --no-deps -e ./quetz 
+pip install -e quetz 
 ```
 
 Use the CLI to create a `Quetz` instance:
 
 ```
-python quetz/quetz/cli.py run test_quetz --create-conf --test --reload
+quetz run test_quetz --create-conf --test --reload
 ```
 
 Links:

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ You should have [mamba](https://github.com/thesnakepit/mamba) or conda installed
 Then create an environment:
 
 ```
-mamba create -n quetz -c conda-forge 'python>=3.7' fastapi authlib httpx=0.12.0 sqlalchemy sqlite \
+mamba create -n quetz -c conda-forge 'python>=3.7' fastapi typer authlib httpx=0.12.0 sqlalchemy sqlite \
 python-multipart uvicorn zstandard conda-build appdirs toml quetz-client
 
 conda activate quetz
-pip install typer
 ```
 
 Get `Quetz` sources:

--- a/init_db.py
+++ b/init_db.py
@@ -3,14 +3,15 @@
 
 import random
 import uuid
+from quetz.config import load_configs
 from quetz.database import init_db, get_session
 from quetz.db_models import (User, Identity, Profile, Channel, ChannelMember, Package,
                              PackageMember, ApiKey)
 
 
 def init_test_db():
+    load_configs()
     init_db()
-
     db = get_session()
 
     testUsers = []

--- a/init_db.py
+++ b/init_db.py
@@ -3,99 +3,104 @@
 
 import random
 import uuid
-from quetz.database import init_db, SessionLocal
+from quetz.database import init_db, get_session
 from quetz.db_models import (User, Identity, Profile, Channel, ChannelMember, Package,
                              PackageMember, ApiKey)
 
-init_db()
 
-db = SessionLocal()
+def init_test_db():
+    init_db()
 
-testUsers = []
+    db = get_session()
 
-try:
-    for index, username in enumerate(['alice', 'bob', 'carol', 'dave']):
-        user = User(id=uuid.uuid4().bytes, username=username)
+    testUsers = []
 
-        identity = Identity(
-            provider='dummy',
-            identity_id=str(index),
-            username=username,
-        )
+    try:
+        for index, username in enumerate(['alice', 'bob', 'carol', 'dave']):
+            user = User(id=uuid.uuid4().bytes, username=username)
 
-        profile = Profile(
-            name=username.capitalize(),
-            avatar_url='/avatar.jpg')
-
-        user.identities.append(identity)
-        user.profile = profile
-        db.add(user)
-        testUsers.append(user)
-
-    for channel_index in range(30):
-        channel = Channel(
-            name=f'channel{channel_index}',
-            description=f'Description of channel{channel_index}',
-            private=False)
-
-        for package_index in range(random.randint(5, 100)):
-            package = Package(
-                name=f'package{package_index}',
-                description=f'Description of package{package_index}')
-            channel.packages.append(package)
-
-            test_user = testUsers[random.randint(0, len(testUsers) - 1)]
-            package_member = PackageMember(
-                package=package,
-                channel=channel,
-                user=test_user,
-                role='owner')
-
-            db.add(package_member)
-
-        if channel_index == 0:
-            package = Package(
-                name=f'xtensor',
-                description=f'Description of xtensor')
-            channel.packages.append(package)
-
-            test_user = testUsers[random.randint(0, len(testUsers) - 1)]
-            package_member = PackageMember(
-                package=package,
-                channel=channel,
-                user=test_user,
-                role='owner')
-
-            db.add(package_member)
-
-            # create API key
-            key = 'E_KaBFstCKI9hTdPM7DQq56GglRHf2HW7tQtq6si370'
-
-            key_user = User(id=uuid.uuid4().bytes)
-
-            api_key = ApiKey(
-                key=key,
-                description='test API key',
-                user=key_user,
-                owner=test_user
+            identity = Identity(
+                provider='dummy',
+                identity_id=str(index),
+                username=username,
             )
-            db.add(api_key)
 
-            key_package_member = PackageMember(
-                user=key_user,
-                channel_name=channel.name,
-                package_name=package.name,
-                role='maintainer')
-            db.add(key_package_member)
+            profile = Profile(
+                name=username.capitalize(),
+                avatar_url='/avatar.jpg')
 
-        db.add(channel)
+            user.identities.append(identity)
+            user.profile = profile
+            db.add(user)
+            testUsers.append(user)
 
-        channel_member = ChannelMember(
-            channel=channel,
-            user=testUsers[random.randint(0, len(testUsers)-1)],
-            role='owner')
+        for channel_index in range(30):
+            channel = Channel(
+                name=f'channel{channel_index}',
+                description=f'Description of channel{channel_index}',
+                private=False)
 
-        db.add(channel_member)
-    db.commit()
-finally:
-    db.close()
+            for package_index in range(random.randint(5, 100)):
+                package = Package(
+                    name=f'package{package_index}',
+                    description=f'Description of package{package_index}')
+                channel.packages.append(package)
+
+                test_user = testUsers[random.randint(0, len(testUsers) - 1)]
+                package_member = PackageMember(
+                    package=package,
+                    channel=channel,
+                    user=test_user,
+                    role='owner')
+
+                db.add(package_member)
+
+            if channel_index == 0:
+                package = Package(
+                    name=f'xtensor',
+                    description=f'Description of xtensor')
+                channel.packages.append(package)
+
+                test_user = testUsers[random.randint(0, len(testUsers) - 1)]
+                package_member = PackageMember(
+                    package=package,
+                    channel=channel,
+                    user=test_user,
+                    role='owner')
+
+                db.add(package_member)
+
+                # create API key
+                key = 'E_KaBFstCKI9hTdPM7DQq56GglRHf2HW7tQtq6si370'
+
+                key_user = User(id=uuid.uuid4().bytes)
+
+                api_key = ApiKey(
+                    key=key,
+                    description='test API key',
+                    user=key_user,
+                    owner=test_user
+                )
+                db.add(api_key)
+
+                key_package_member = PackageMember(
+                    user=key_user,
+                    channel_name=channel.name,
+                    package_name=package.name,
+                    role='maintainer')
+                db.add(key_package_member)
+
+            db.add(channel)
+
+            channel_member = ChannelMember(
+                channel=channel,
+                user=testUsers[random.randint(0, len(testUsers)-1)],
+                role='owner')
+
+            db.add(channel_member)
+        db.commit()
+    finally:
+        db.close()
+
+if __name__ == '__main__':
+    init_test_db()

--- a/quetz/auth_github.py
+++ b/quetz/auth_github.py
@@ -4,7 +4,7 @@
 from starlette.responses import RedirectResponse
 from fastapi import APIRouter, Request
 from authlib.integrations.starlette_client import OAuth
-from .database import SessionLocal
+from .database import get_session
 from .dao_github import get_user_by_github_identity
 from quetz import config
 import json
@@ -47,7 +47,7 @@ async def authorize(request: Request):
     token = await oauth.github.authorize_access_token(request)
     resp = await oauth.github.get('user', token=token)
     profile = resp.json()
-    db = SessionLocal()
+    db = get_session()
     try:
         user = get_user_by_github_identity(db, profile)
     finally:

--- a/quetz/auth_github.py
+++ b/quetz/auth_github.py
@@ -13,18 +13,20 @@ import uuid
 router = APIRouter()
 oauth = OAuth()
 
-# Register the app here: https://github.com/settings/applications/new
-oauth.register(
-    name='github',
-    client_id=config.github_client_id,
-    client_secret=config.github_client_secret,
-    access_token_url='https://github.com/login/oauth/access_token',
-    access_token_params=None,
-    authorize_url='https://github.com/login/oauth/authorize',
-    authorize_params=None,
-    api_base_url='https://api.github.com/',
-    client_kwargs={'scope': 'user:email'},
-)
+
+def register():
+    # Register the app here: https://github.com/settings/applications/new
+    oauth.register(
+        name='github',
+        client_id=config.github_client_id,
+        client_secret=config.github_client_secret,
+        access_token_url='https://github.com/login/oauth/access_token',
+        access_token_params=None,
+        authorize_url='https://github.com/login/oauth/authorize',
+        authorize_params=None,
+        api_base_url='https://api.github.com/',
+        client_kwargs={'scope': 'user:email'},
+    )
 
 
 async def validate_token(token):

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -1,0 +1,283 @@
+# Copyright 2020 QuantStack
+# Distributed under the terms of the Modified BSD License.
+
+import typer
+import os
+import shutil
+import uvicorn
+import json
+import random
+import uuid
+from pathlib import Path
+
+from quetz.config import (create_config, load_configs, _user_dir, _env_prefix,
+                          _env_config_file)
+from quetz.database import init_db, get_session
+from quetz.db_models import (User, Identity, Profile, Channel, ChannelMember, Package,
+                             PackageMember, ApiKey)
+
+app = typer.Typer()
+
+_deployements_file = os.path.join(_user_dir, 'deployements.json')
+
+
+def _fill_test_database():
+    db = get_session()
+    testUsers = []
+    try:
+        for index, username in enumerate(['alice', 'bob', 'carol', 'dave']):
+            user = User(id=uuid.uuid4().bytes, username=username)
+
+            identity = Identity(
+                provider='dummy',
+                identity_id=str(index),
+                username=username,
+            )
+
+            profile = Profile(
+                name=username.capitalize(),
+                avatar_url='/avatar.jpg')
+
+            user.identities.append(identity)
+            user.profile = profile
+            db.add(user)
+            testUsers.append(user)
+
+        for channel_index in range(30):
+            channel = Channel(
+                name=f'channel{channel_index}',
+                description=f'Description of channel{channel_index}',
+                private=False)
+
+            for package_index in range(random.randint(5, 100)):
+                package = Package(
+                    name=f'package{package_index}',
+                    description=f'Description of package{package_index}')
+                channel.packages.append(package)
+
+                test_user = testUsers[random.randint(0, len(testUsers) - 1)]
+                package_member = PackageMember(
+                    package=package,
+                    channel=channel,
+                    user=test_user,
+                    role='owner')
+
+                db.add(package_member)
+
+            if channel_index == 0:
+                package = Package(
+                    name=f'xtensor',
+                    description=f'Description of xtensor')
+                channel.packages.append(package)
+
+                test_user = testUsers[random.randint(0, len(testUsers) - 1)]
+                package_member = PackageMember(
+                    package=package,
+                    channel=channel,
+                    user=test_user,
+                    role='owner')
+
+                db.add(package_member)
+
+                # create API key
+                key = 'E_KaBFstCKI9hTdPM7DQq56GglRHf2HW7tQtq6si370'
+
+                key_user = User(id=uuid.uuid4().bytes)
+
+                api_key = ApiKey(
+                    key=key,
+                    description='test API key',
+                    user=key_user,
+                    owner=test_user
+                )
+                db.add(api_key)
+
+                key_package_member = PackageMember(
+                    user=key_user,
+                    channel_name=channel.name,
+                    package_name=package.name,
+                    role='maintainer')
+                db.add(key_package_member)
+
+            db.add(channel)
+
+            channel_member = ChannelMember(
+                channel=channel,
+                user=testUsers[random.randint(0, len(testUsers)-1)],
+                role='owner')
+
+            db.add(channel_member)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _get_deployements():
+
+    if os.path.exists(_deployements_file):
+        return _cleaned_deployements()
+    else:
+        Path(_user_dir).mkdir(parents=True, exist_ok=True) 
+        return {}
+
+
+def _store_deployement(path: str, config_file_name: str):
+
+    json_ = {path: config_file_name}
+    deployements = _get_deployements()
+
+    deployements.update(json_)
+    with open(_deployements_file, 'w') as f:
+        json.dump(deployements, f)
+
+
+def _cleaned_deployements():
+
+    with open(_deployements_file, 'r') as f:
+        deployements = json.load(f)
+
+    to_delete = []
+    for path, f in deployements.items():
+        config_file = os.path.join(path, f)
+        if not os.path.exists(config_file):  # User has deleted the instance without CLI
+            to_delete.append(path)
+
+    cleaned_deployements = {path: f for path, f in deployements.items() 
+                            if path not in to_delete}
+
+    if len(to_delete) > 0:
+        with open(_deployements_file, 'w') as f:
+            json.dump(cleaned_deployements, f)
+
+    return cleaned_deployements
+
+
+def _clean_deployements():
+
+    _ = _cleaned_deployements()
+
+
+@app.command()
+def create(path: str, 
+           config_file_name: str = "config.toml", 
+           create_conf: bool = False, 
+           test: bool = False):
+
+    abs_path = os.path.abspath(path)
+    config_file = os.path.join(path, config_file_name)
+    deployements = _get_deployements()
+
+    if os.path.exists(path):
+        if abs_path in deployements:
+            delete_ = typer.confirm('Quetz deployement exists at {}.\n'.format(path) +
+                                    'Overwrite it?')
+            if delete_:
+                delete(path, force=True)
+                create(path, config_file_name, create_conf, test)
+                return
+            else:
+                typer.echo('Use the start command to start a deployement.')
+                raise typer.Abort()
+
+        # only authorize path with a config file to avoid deletion of unexpected files
+        # when deleting Quetz instance
+        if not all([f in [config_file_name] for f in os.listdir(path)]):
+            typer.echo('Quetz deployement not allowed at {}.\n'.format(path) +
+                       'The path should not contain more than the configuration file.')
+            raise typer.Abort()
+
+        if not os.path.exists(config_file) and not create_conf:
+            typer.echo('Config file "{}" does not exist at {}.\n'.format(config_file_name,
+                                                                         path) + 
+                       'Use --create-conf option to generate a default config file.')
+            raise typer.Abort()
+    else:
+        if not create_conf:
+            typer.echo('No configuration file provided.\n' + 
+                       'Use --create-conf option to generate a default config file.')
+            raise typer.Abort()
+
+        Path(path).mkdir(parents=True)
+
+    if not os.path.exists(config_file):
+        conf = create_config()
+        with open(config_file, 'w') as f:
+            f.write(conf)
+
+    os.environ['QUETZ_CONFIG_FILE'] = config_file
+    load_configs(config_file)
+
+    os.chdir(path)
+    Path('channels').mkdir()
+    init_db()
+ 
+    if test:
+        _fill_test_database()
+
+    _store_deployement(abs_path, config_file_name)
+
+
+@app.command()
+def start(path: str, port: int = 8000, reload: bool = False):
+
+    abs_path = os.path.abspath(path)
+    deployements = _get_deployements()
+
+    try:
+        config_file_name = deployements[abs_path]
+    except KeyError:
+        typer.echo('No Quetz deployement found at {}.'.format(path))
+        raise typer.Abort()
+
+    config_file = os.path.join(abs_path, config_file_name)
+    os.environ[_env_prefix + _env_config_file] = config_file
+    os.chdir(path)
+
+    import quetz
+    quetz_src = os.path.dirname(quetz.__file__)
+    uvicorn.run("quetz.main:app", reload=reload, reload_dirs=(quetz_src, ), port=port)
+
+
+@app.command()
+def run(path: str, 
+        config_file_name: str = "config.toml", 
+        create_conf: bool = False, 
+        test: bool = False,
+        port: int = 8000,
+        reload: bool = False):
+
+    abs_path = os.path.abspath(path)
+    create(abs_path, config_file_name, create_conf, test)
+    start(abs_path, port, reload)
+
+
+@app.command()
+def delete(path: str, force: bool = False):
+
+    abs_path = os.path.abspath(path)
+    deployements = _get_deployements()
+
+    try:
+        _ = deployements[abs_path]
+    except KeyError:
+        typer.echo('No Quetz deployement found at {}.'.format(path))
+        raise typer.Abort()
+
+    delete = force or typer.confirm("Delete Quetz deployement at {}?".format(path))
+    if not delete:
+        raise typer.Abort()
+
+    shutil.rmtree(abs_path)
+    _clean_deployements()
+
+
+@app.command()
+def list():
+    deployements = _get_deployements()
+
+    if len(deployements) > 0:
+        typer.echo('\n'.join([p for p in deployements]))
+
+
+if __name__ == "__main__":
+    app()

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -97,12 +97,13 @@ def _read_config(filename):
 def create_config(client_id: str = "",
                   client_secret: str = "", 
                   database_url: str = "sqlite:///./quetz.sqlite",
-                  secret: str = b64encode(token_bytes(32)).decode()):
+                  secret: str = b64encode(token_bytes(32)).decode(),
+                  https: str = 'true'):
 
     with open(os.path.join(os.path.dirname(__file__), "config.toml"), 'r') as f:
         config = ''.join(f.readlines())
 
-    return config.format(client_id, client_secret, database_url, secret)
+    return config.format(client_id, client_secret, database_url, secret, https)
 
 
 def load_configs(configuration: str = None):
@@ -112,7 +113,7 @@ def load_configs(configuration: str = None):
     config_files = [os.path.join(d, _filename) for d in config_dirs]
     config_env = os.getenv(f"{_env_prefix}{_env_config_file}")
 
-    for f in (config_env, configuration):
+    for f in (configuration, config_env):
         if f and os.path.isfile(f):
             config_files.append(f)
 

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -3,7 +3,7 @@
 
 from distutils.util import strtobool
 import os
-from typing import Any, Optional, NamedTuple, Type
+from typing import Any, NamedTuple, Type, Dict, NoReturn, Union
 from secrets import token_bytes
 from base64 import b64encode
 
@@ -60,11 +60,21 @@ _configs = (
 )
 
 
-def _get_value(entry, config):
-    value = os.getenv(entry.env_var)
-    if value:
-        return entry.casted(value)
+def _get_value(entry: ConfigEntry, config: Dict[str, Union[str, Dict[str, str]]]) -> Union[str, bool]:
+    """ Get an entry value from a configuration mapping.
 
+    Parameters
+    ----------
+    entry : ConfigEntry
+        The entry to search
+    config : Dict[str, Union[str, Dict[str, str]]]
+        A mapping where to search the entry
+
+    Returns
+    -------
+    value : Union[str, bool]
+        The entry value
+    """
     try:
         if entry.section:
             value = config[entry.section][entry.name]
@@ -72,6 +82,7 @@ def _get_value(entry, config):
             value = config[entry.name]
 
         return entry.casted(value)
+
     except KeyError:
         if entry.required:
             if entry.section:
@@ -85,7 +96,19 @@ def _get_value(entry, config):
     raise ConfigError(f"'{entry.name}' unset but no default specified")
 
 
-def _read_config(filename):
+def _read_config(filename: str) -> Dict[str, str]:
+    """ Read a configuration file from its path.
+
+    Parameters
+    ----------
+    filename : str
+        The path of the configuration file
+
+    Returns
+    -------
+    configuration : Dict[str, str]
+        The mapping of configuration variables found in the file
+    """
     with open(filename) as f:
         try:
             t = toml.load(f)
@@ -98,29 +121,66 @@ def create_config(client_id: str = "",
                   client_secret: str = "", 
                   database_url: str = "sqlite:///./quetz.sqlite",
                   secret: str = b64encode(token_bytes(32)).decode(),
-                  https: str = 'true'):
+                  https: str = 'true') -> str:
+    """ Create a configuration file from a template.
 
-    with open(os.path.join(os.path.dirname(__file__), "config.toml"), 'r') as f:
+    Parameters
+    ----------
+    client_id : str, optional
+        The Github client ID {default=""}
+    client_secret : str, optional
+        The Github client secret {default=""}
+    database_url : str, optional
+        The URL of the database {default="sqlite:///./quetz.sqlite"}
+    secret : str, optional
+        The secret of the session {default=randomly create}
+    https : str, optional
+        Whether to use HTTPS, or not {default="true"}
+
+    Returns
+    -------
+    configuration : str
+        The configuration
+    """
+    with open(os.path.join(os.path.dirname(__file__), _filename), 'r') as f:
         config = ''.join(f.readlines())
 
     return config.format(client_id, client_secret, database_url, secret, https)
 
 
-def load_configs(configuration: str = None):
+def load_configs(deployment_config: str = None) -> NoReturn:
+    """ Load configurations from various places.
+
+    Order of importance for configuration is :
+    host < user profile < deployment < configuration file from env var < value from env var
+
+    Parameters
+    ----------
+    deployment_config: str, optional
+        The configuration stored at deployment level
+    """
 
     config = {}
     config_dirs = [_site_dir, _user_dir]
     config_files = [os.path.join(d, _filename) for d in config_dirs]
-    config_env = os.getenv(f"{_env_prefix}{_env_config_file}")
+    config_file_env = os.getenv(f"{_env_prefix}{_env_config_file}")
 
-    for f in (configuration, config_env):
+    for f in (deployment_config, config_file_env):
         if f and os.path.isfile(f):
             config_files.append(f)
 
+    # In order, get configuration from _site_dir, _user_dir, deployment_config, config_file_env
     for f in config_files:
         if os.path.isfile(f):
             config.update(_read_config(f))
 
     for entry in _configs:
-        value = _get_value(entry, config)
+        env_var_value = os.getenv(entry.env_var)
+
+        # Override the configuration files if an env variable is defined for the entry
+        if env_var_value:
+            value = entry.casted(env_var_value)
+        else:
+            value = _get_value(entry, config)
+
         globals()[entry.full_name] = value

--- a/quetz/config.toml
+++ b/quetz/config.toml
@@ -8,4 +8,4 @@ database_url = "{}"
 
 [session]
 secret = "{}"
-https_only = false
+https_only = {}

--- a/quetz/config.toml
+++ b/quetz/config.toml
@@ -1,0 +1,11 @@
+[github]
+# Register the app here: https://github.com/settings/applications/new
+client_id = "{}"
+client_secret = "{}"
+
+[sqlalchemy]
+database_url = "{}"
+
+[session]
+secret = "{}"
+https_only = false

--- a/quetz/database.py
+++ b/quetz/database.py
@@ -4,17 +4,24 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-from quetz import config
 
-engine = create_engine(
-    config.sqlalchemy_database_url,
-    connect_args={'check_same_thread': False},
-    echo=False
-)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+from quetz import config
 
 Base = declarative_base()
 
 
+def _get_engine():
+    engine = create_engine(
+        config.sqlalchemy_database_url,
+        connect_args={'check_same_thread': False},
+        echo=False
+    )
+    return engine
+
+
+def get_session():
+    return sessionmaker(autocommit=False, autoflush=False, bind=_get_engine())()
+
+
 def init_db():
-    Base.metadata.create_all(engine)
+    Base.metadata.create_all(_get_engine())

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -28,7 +28,7 @@ config.load_configs()
 
 from quetz import auth_github
 from quetz.dao import Dao
-from .database import get_session as get_db_sessions
+from .database import get_session as get_db_session
 from quetz import rest_models
 from quetz import db_models
 from quetz import authorization
@@ -47,7 +47,7 @@ app.include_router(auth_github.router)
 # Dependency injection
 
 def get_db():
-    db = get_db_sessions()
+    db = get_db_session()
     try:
         yield db
     finally:

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -23,10 +23,12 @@ from io import BytesIO
 from zipfile import ZipFile
 import zstandard
 
-from quetz import auth_github
 from quetz import config
+config.load_configs()
+
+from quetz import auth_github
 from quetz.dao import Dao
-from .database import SessionLocal
+from .database import get_session as get_db_sessions
 from quetz import rest_models
 from quetz import db_models
 from quetz import authorization
@@ -45,7 +47,7 @@ app.include_router(auth_github.router)
 # Dependency injection
 
 def get_db():
-    db = SessionLocal()
+    db = get_db_sessions()
     try:
         yield db
     finally:

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -24,16 +24,17 @@ from zipfile import ZipFile
 import zstandard
 
 from quetz import config
-config.load_configs()
-
 from quetz import auth_github
 from quetz.dao import Dao
-from .database import get_session as get_db_session
+from quetz.database import get_session as get_db_session
 from quetz import rest_models
 from quetz import db_models
 from quetz import authorization
 
 app = FastAPI()
+
+config.load_configs()
+auth_github.register()
 
 app.add_middleware(
     SessionMiddleware,

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,9 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     python_requires='>=3.7',
+    entry_points={
+        'console_scripts': [
+            'quetz = quetz.cli:app'
+        ]
+    },
 )


### PR DESCRIPTION
Description
--
Create a CLI to simplify the creation of `Quetz` instances.
This PR is related to this [issue](https://github.com/TheSnakePit/quetz/issues/44) about how to bootstrap install.

Few commands are covered at this time: 
- `create`: set-up a directory well configured to start Quetz
- `start`: start Quetz for an already configured directory
- `run`: create + start
- `list`: list the already created Quetz instances
- `delete`: delete an instance
 
Discussion
--
- I tried to make possible to create multiple instance of `Quetz`, using different ports. Maybe I could be useful, or not (?)
- Unit tests should be implemented
- Test files `init_db.py`, `set_env_dev.sh`, `dev_config.toml` could/should be removed

There are many improvements to do, but it's a starting point.
Let me know if this could help!