### PR TITLE
add pagination and search to front- and backend for packages

### DIFF
--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -83,6 +83,9 @@ class Dao:
         if q:
             query = query.filter(Package.name.like(f'%{q}%'))
 
+        if limit < 0:
+            return query.all()
+
         return self.get_paginated_result(query, skip, limit)
 
     def get_channel(self, channel_name: str):

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1,7 +1,7 @@
 # Copyright 2020 QuantStack
 # Distributed under the terms of the Modified BSD License.
 
-from typing import List, Optional, Generic, TypeVar
+from typing import List, Optional, Generic, TypeVar, Union
 from fastapi import Depends, FastAPI, HTTPException, status, Request, File, UploadFile, APIRouter,\
     Form
 from fastapi.responses import HTMLResponse
@@ -207,12 +207,17 @@ def post_channel(
     dao.create_channel(new_channel, user_id, authorization.OWNER)
 
 
-@api_router.get('/channels/{channel_name}/packages', response_model=rest_models.PaginatedResponse[rest_models.Package],
-         tags=['packages'])
+@api_router.get('/channels/{channel_name}/packages',
+                response_model=Union[rest_models.PaginatedResponse[rest_models.Package], List[rest_models.Package]],
+                tags=['packages'])
 def get_packages(
         channel: db_models.Channel = Depends(get_channel_or_fail),
         dao: Dao = Depends(get_dao),
-        skip: int = 0, limit: int = 10, q: str = None):
+        skip: int = 0, limit: int = -1, q: str = None):
+    """
+    Retrieve all packages in a channel.
+    A limit of -1 returns an unpaginated result with all packages. Otherwise, pagination is applied.
+    """
 
     return dao.get_packages(channel.name, skip, limit, q)
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1,7 +1,7 @@
 # Copyright 2020 QuantStack
 # Distributed under the terms of the Modified BSD License.
 
-from typing import List, Optional
+from typing import List, Optional, Generic, TypeVar
 from fastapi import Depends, FastAPI, HTTPException, status, Request, File, UploadFile, APIRouter,\
     Form
 from fastapi.responses import HTMLResponse
@@ -207,7 +207,7 @@ def post_channel(
     dao.create_channel(new_channel, user_id, authorization.OWNER)
 
 
-@api_router.get('/channels/{channel_name}/packages', response_model=List[rest_models.Package],
+@api_router.get('/channels/{channel_name}/packages', response_model=rest_models.PaginatedResponse[rest_models.Package],
          tags=['packages'])
 def get_packages(
         channel: db_models.Channel = Depends(get_channel_or_fail),
@@ -486,10 +486,10 @@ def invalid_api():
 
 app.mount("/channels", StaticFiles(directory='channels', html=True), name="channels")
 
-
-if os.path.isfile('quetz_frontend/dist/index.html'):
+print(os.getcwd())
+if os.path.isfile('../quetz_frontend/dist/index.html'):
     print('dev frontend found')
-    app.mount("/", StaticFiles(directory='quetz_frontend/dist', html=True), name="frontend")
+    app.mount("/", StaticFiles(directory='../quetz_frontend/dist', html=True), name="frontend")
 elif os.path.isfile(f'{sys.prefix}/share/quetz/frontend/index.html'):
     print('installed frontend found')
     app.mount("/", StaticFiles(directory=f'{sys.prefix}/share/quetz/frontend/', html=True), name="frontend")

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from pydantic.generics import GenericModel
+from typing import List, Optional, TypeVar, Generic
 from datetime import datetime
 
+T = TypeVar('T')
 
 class BaseProfile(BaseModel):
     name: Optional[str]
@@ -44,6 +46,10 @@ class Member(BaseModel):
 
 Role = Field(None, regex='owner|maintainer|member')
 
+class Pagination(BaseModel):
+    skip: int = Field(0, title='The number of skipped records')
+    limit: int = Field(0, title='The maximum number of returned records')
+    all_records_count: int = Field(0, title="The number of available records")
 
 class Channel(BaseModel):
     name: str = Field(None, title='The name of the channel', max_length=50)
@@ -53,7 +59,6 @@ class Channel(BaseModel):
     class Config:
         orm_mode = True
 
-
 class Package(BaseModel):
     name: str = Field(None, title='The name of package', max_length=50)
     description: str = Field(None, title='The description of the package', max_length=300)
@@ -61,6 +66,9 @@ class Package(BaseModel):
     class Config:
         orm_mode = True
 
+class PaginatedResponse(GenericModel, Generic[T]):
+    pagination: Pagination = Field(None, title="Pagination object")
+    result: List[T] = Field([], title="Result objects")
 
 class PostMember(BaseModel):
     username: str

--- a/quetz_frontend/src/views/Packages.vue
+++ b/quetz_frontend/src/views/Packages.vue
@@ -4,8 +4,13 @@
     <div class="bx--col-lg-13 bx--offset-lg-3">
         <h3 class="bx--data-table-header">Packages in {{ $route.params.channel_id }}</h3>
         <cv-data-table
-          :columns="columns" :data="data" ref="table"></cv-data-table>
-
+          :columns="columns"
+          :data="data"
+          :pagination="pagination"
+          @search="onFilter" searchLabel="Filter" searchPlaceholder="Filter" searchClearLabel="Clear filter"
+          @pagination="loadPagination"
+          ref="table">
+        </cv-data-table>
     </div>
   </div>
 </div>
@@ -13,13 +18,6 @@
 
 <script>
   export default {
-
-    /*  {
-    "name": "channel0",
-    "description": "Description of channel0",
-    "private": false
-  },
-    */
     data: function () {
       return {
         columns: [],
@@ -28,18 +26,44 @@
       }
     },
     methods: {
-      fetchData: function() {
-        return fetch("/api/channels/" + this.$route.params.channel_id + "/packages").then((msg) => {
+      // TODO double request currently, also save value of #packages to display in local storage?
+      loadPagination: function(args, searchquery) {
+        let url = "/api/channels/" + this.$route.params.channel_id + "/packages?"
+        this.selected_pagesize = args['length'];
+        url += new URLSearchParams({
+          limit: args['length'],
+          skip: args['start'] - 1
+        });
+        if (searchquery)
+        {
+          url += "&" + new URLSearchParams({
+            q: searchquery
+          })
+        }
+        return fetch(url).then((msg) => {
           return msg.json().then((decoded) => {
               console.log(decoded);
               this.columns = ["Name", "Description"];
-              this.data = decoded.map((el) => [el.name, el.description]);
+              console.log(decoded.pagination)
+              this.pagination = {
+                numberOfItems: decoded.pagination.all_records_count,
+                pageSizes: [25, 50, 100, 1000]
+              };
+              this.numberOfItems = decoded.pagination.all_records_count;
+              this.data = decoded.result.map((el) => [el.name, el.description]);
           });
         });
-      }
+      },
+      onFilter: function(query) {
+        this.loadPagination({length: 25, start: 1}, query)
+      },
     },
     created: function() {
-      this.fetchData();
+      this.pagination = {
+        numberOfItems: 0,
+        pageSizes: [25, 50, 100, 1000]
+      };
+      this.loadPagination({length: 25, start: 1});
     },
 }
 </script>


### PR DESCRIPTION
This adds an initial API for pagination to the backend, and uses it in the frontend.
Also adds a search thing to the frontend and uses the `q` parameter to search in the backend.

This does break the API for `/api/channels/{}/packages` though. So I am wondering if we should activate this behind a query parameter (`&pagination=true`) or if we should give it a more generic term?

With the current API we can't know the total amount of available packages. So we should either return _all_ packages or add that value somehow.