### PR TITLE
Add Google OAuth 2.0 OpenID Connect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ url = "https://..."
 
 Be sure to set the url field if not using AWS.
 
+## Google OAuth 2.0 OpenID Connect
+
+To enable auth via Google, you will need to register an application at: https://console.developers.google.com/apis/credentials
+
+Then add the client secret & ID to a `google` section of your `config.toml`:
+
+```
+[google]
+client_id = "EXAMPLEID420127570681-6rbcgdj683l3odc3nqearn2dr3pnaisq.apps.googleusercontent.com"
+client_secret = "EXAMPLESECRETmD-7UXVCMZV3C7b-kZ9yf70"
+```
+
 ## Frontend
 
 Quetz comes with a initial frontend implementation. It can be found in quetz_frontend.

--- a/quetz/auth_github.py
+++ b/quetz/auth_github.py
@@ -40,11 +40,11 @@ async def validate_token(token):
 @router.route('/auth/github/login')
 async def login(request):
     github = oauth.create_client('github')
-    redirect_uri = request.url_for('authorize')
+    redirect_uri = request.url_for('authorize_github')
     return await github.authorize_redirect(request, redirect_uri)
 
 
-@router.route('/auth/github/authorize')
+@router.route('/auth/github/authorize', name='authorize_github')
 async def authorize(request: Request):
     token = await oauth.github.authorize_access_token(request)
     resp = await oauth.github.get('user', token=token)

--- a/quetz/auth_google.py
+++ b/quetz/auth_google.py
@@ -1,0 +1,64 @@
+# Copyright 2020 QuantStack, Codethink Ltd
+# Distributed under the terms of the Modified BSD License.
+
+from starlette.responses import RedirectResponse
+from fastapi import APIRouter, Request
+from authlib.integrations.starlette_client import OAuth
+from .database import get_session
+from .dao_google import get_user_by_google_identity
+import uuid
+
+router = APIRouter()
+oauth = OAuth()
+
+
+def register(config):
+    # Register the app here: https://console.developers.google.com/apis/credentials
+    oauth.register(
+        name='google',
+        client_id=config.google_client_id,
+        client_secret=config.google_client_secret,
+        server_metadata_url='https://accounts.google.com/.well-known/openid-configuration',
+        client_kwargs={'scope': 'openid email profile'},
+        quetz_db_url=config.sqlalchemy_database_url,
+        prompt='select_account'
+    )
+
+
+async def validate_token(token):
+    resp = await oauth.google.get('https://openidconnect.googleapis.com/v1/userinfo', token=token)
+    if resp.status_code == 401:
+        return False
+    return True
+
+
+@router.route('/auth/google/login')
+async def login_google(request: Request):
+    google = oauth.create_client('google')
+    redirect_uri = request.url_for('authorize_google')
+    return await google.authorize_redirect(request, redirect_uri)
+
+
+@router.route('/auth/google/authorize', name='authorize_google')
+async def authorize(request: Request):
+    token = await oauth.google.authorize_access_token(request)
+    profile= await oauth.google.parse_id_token(request, token)
+    db = get_session(oauth.google.server_metadata['quetz_db_url'])
+    try:
+        user = get_user_by_google_identity(db, profile)
+    finally:
+        db.close()
+
+    request.session['user_id'] = str(uuid.UUID(bytes=user.id))
+
+    request.session['identity_provider'] = 'google'
+
+    request.session['token'] = token
+
+    return RedirectResponse('/')
+
+
+@router.route('/auth/google/revoke')
+async def revoke(request):
+    return RedirectResponse(
+        f'https://myaccount.google.com/permissions')

--- a/quetz/basic_frontend/index.html
+++ b/quetz/basic_frontend/index.html
@@ -6,8 +6,10 @@
 </head>
 <body>
 <h1>Quetz</h1>
-<a href="/auth/github/login" style="margin-right: 100px" id="login">login with github</a>
+<a href="/auth/github/login" style="margin-right: 100px" id="github_login">login with github</a>
+<a href="/auth/google/login" style="margin-right: 100px" id="google_login">login with google</a>
 <a href="/auth/github/revoke" style="margin-right: 100px" id="revoke">revoke github</a>
+<a href="/auth/google/revoke" style="margin-right: 100px" id="revoke">revoke google</a>
 <a href="/auth/logout" id="logout">logout</a>
 <div id="status"></div>
 

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -69,6 +69,10 @@ class Config:
             ConfigEntry("url", str, default=""),
             ConfigEntry("bucket_prefix", str, default=""),
             ConfigEntry("bucket_suffix", str, default="")
+        ], required=False),
+        ConfigSection("google", [
+            ConfigEntry("client_id", str),
+            ConfigEntry("client_secret", str)
         ], required=False)
     )
     _config_dirs = [_site_dir, _user_dir]
@@ -192,6 +196,21 @@ class Config:
                 'channels_dir': 'channels'
             })
 
+    def configured_section(self, section: str) -> bool:
+        """Return if a given section has been configured.
+
+        Parameters
+        ----------
+        provider: str
+            The section name in config
+
+        Returns
+        -------
+        bool
+            Wether or not the given section is configured
+        """
+
+        return bool(self.config.get(section))
 
 def create_config(client_id: str = "",
                   client_secret: str = "",
@@ -203,9 +222,9 @@ def create_config(client_id: str = "",
     Parameters
     ----------
     client_id : str, optional
-        The Github client ID {default=""}
+        The client ID {default=""}
     client_secret : str, optional
-        The Github client secret {default=""}
+        The client secret {default=""}
     database_url : str, optional
         The URL of the database {default="sqlite:///./quetz.sqlite"}
     secret : str, optional

--- a/quetz/dao_google.py
+++ b/quetz/dao_google.py
@@ -1,0 +1,61 @@
+# Copyright 2020 QuantStack, Codethink Ltd
+# Distributed under the terms of the Modified BSD License.
+
+from sqlalchemy.orm import Session
+import uuid
+
+from .db_models import Identity, Profile, User
+
+
+def create_user_with_google_identity(db: Session, google_profile) -> User:
+    user = User(id=uuid.uuid4().bytes, username=google_profile['email'])
+
+    identity = Identity(
+        provider='google',
+        identity_id=google_profile['sub'],
+        username=google_profile['email'],
+    )
+
+    profile = Profile(
+        name=google_profile['name'],
+        avatar_url=google_profile['picture'])
+
+    user.identities.append(identity)
+    user.profile = profile
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def user_google_profile_changed(user, identity, profile):
+    if (identity.username != profile['email']
+          or user.profile.name != profile['name']
+          or user.profile.avatar_url != profile['picture']):
+        return True
+
+    return False
+
+
+def update_user_from_google_profile(db: Session, user, identity, profile) -> User:
+    identity.username = profile['email']
+    user.profile.name = profile['name']
+    user.profile.avatar_url = profile['picture']
+
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def get_user_by_google_identity(db: Session, profile) -> User:
+    user, identity = db.query(User, Identity).join(Identity) \
+        .filter(Identity.provider == 'google') \
+        .filter(Identity.identity_id == profile['sub']) \
+        .one_or_none() or (None, None)
+
+    if user:
+        if user_google_profile_changed(user, identity, profile):
+            return update_user_from_google_profile(db, user, identity, profile)
+        return user
+
+    return create_user_with_google_identity(db, profile)

--- a/quetz_frontend/src/components/Header.vue
+++ b/quetz_frontend/src/components/Header.vue
@@ -14,8 +14,11 @@
         <img class="avatar-img" :src="avatar_url"  />
       </template>
       <template v-else>
-        <cv-button v-on:click="signin">
-          Sign In
+        <cv-button v-on:click="signinGithub">
+          Sign In Via Github
+        </cv-button>
+        <cv-button v-on:click="signinGoogle">
+          Sign In Via Google
         </cv-button>
       <cv-header-global-action aria-label="User avatar" aria-controls="user-panel">
         <!-- <img :src="avatar_url" v-if="avatar_url" /> -->
@@ -58,9 +61,13 @@
       this.me();
     },
     methods: {
-      signin() {
+      signinGithub() {
         window.location.href = "/auth/github/login";
-        console.log("Signing in");
+        console.log("Signing in via github");
+      },
+      signinGoogle() {
+        window.location.href = "/auth/google/login";
+        console.log("Signing in via google");
       },
       logout() {
         window.location.href = "/auth/logout";


### PR DESCRIPTION
**!!A few things to tick off before merging!!**

- [x] It would be great if a member of QuantStack/Maintainers could provide an id/secret for the `dev_config.toml`, I believe the current credentials for GitHub are linked to a @mariobuikhuizen endpoint. If so I will add to the PR before merge.

- [x] Google doesn't guarantee a `login` (i.e username/nickname) field like GitHub provides, as such I've gone with the users email for the same DB field (see the [OIDC Standard](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) & what Google will [provide](https://accounts.google.com/.well-known/openid-configuration)). With this is mind, do we want to align `login/username == email` internally in quetz for all $providers as we already ask for it in the GitHub Scope? Outside of OAuth it's probably more reliable to assume we'd receive email addresses over usernames too imo.

- [x] There is no support for having multiple auth providers for the same user Quetz user. I believe it would be nice for a single Quetz user account to auth with N providers and we already store a `provider` value which could be expanded on. Right now I don't think it's much of an issue and could be worked on in a single module, but still worth considering. This module could also be the entry point for a public API providing a mechanism for adding further auth providers/systems to Quetz.

- [x] The Google section of config is set to be required (although entries/fields can be left empty) as with GitHub, with recent changes to [Config](https://github.com/TheSnakePit/quetz/commit/9b35fc487504950e6cb5393cb67420c031631275) we could allow the section to be optional.

**The points above have been covered in the comments. For now Google Auth will be optional config, and further work will be done to integrate multi auth per user going forward**

This could be considered part of https://github.com/TheSnakePit/quetz/issues/41