### PR TITLE
README improvement & examples simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ quetz run test_quetz --create-conf --dev --reload
 
 Links:
  * http://localhost:8000/ - Login with your github account
- * http://localhost:8000/api/dummylogin/[ alice | bob | carol | dave] - Login with test user
+ * http://localhost:8000/api/dummylogin/alice  - Login with test user, one of [alice | bob | carol | dave]
  * http://localhost:8000/docs - Swagger UI for this REST service
 
 Download `xtensor` as test package:

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -47,13 +47,13 @@ def _fill_test_database(database_url: str) -> NoReturn:
             db.add(user)
             testUsers.append(user)
 
-        for channel_index in range(30):
+        for channel_index in range(3):
             channel = Channel(
                 name=f'channel{channel_index}',
                 description=f'Description of channel{channel_index}',
                 private=False)
 
-            for package_index in range(random.randint(5, 100)):
+            for package_index in range(random.randint(5, 10)):
                 package = Package(
                     name=f'package{package_index}',
                     description=f'Description of package{package_index}')


### PR DESCRIPTION
The example link for dummyuser renders (http://localhost:8000/api/dummylogin/%5B) and returns Internal Server Error. Should rather be one of the test users like alice.